### PR TITLE
Handle empty market forecast requests

### DIFF
--- a/backend/blueprints/markets.py
+++ b/backend/blueprints/markets.py
@@ -4,16 +4,37 @@ from services.market_service import forecast
 
 bp = Blueprint("markets", __name__, url_prefix="/api/markets")
 
+
 class MarketReq(BaseModel):
-    commodity: str
-    mandi: str
+    """Request model for market forecast.
+
+    `commodity` and `mandi` are optional so that the endpoint can return a
+    dummy forecast even when the frontend does not supply any payload.  This
+    keeps the dashboard functional during early development where the real
+    values might not yet be available.
+    """
+
+    commodity: str = "wheat"
+    mandi: str = "delhi"
     horizon_days: int = Field(default=7, ge=1, le=30)
+
 
 @bp.post("/forecast")
 def markets_forecast():
-    try:
-        body = MarketReq.model_validate_json(request.data)
-    except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+    """Return a simple price forecast.
+
+    If the client sends an empty body we fall back to the defaults defined in
+    ``MarketReq``.  Any validation errors are reported with a 400 response
+    rather than bubbling up as a 500.
+    """
+
+    if not request.data:
+        body = MarketReq()
+    else:
+        try:
+            body = MarketReq.model_validate_json(request.data)
+        except ValidationError as e:
+            return jsonify({"error": e.errors()}), 400
+
     out = forecast(body.commodity, body.mandi, body.horizon_days)
     return jsonify(out)

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -61,8 +61,10 @@ export function marketForecast(body) {
   return http("/markets/forecast", { method: "POST", json: body });
 }
 // Backwards-compatible alias some pages may import
-export function fetchMarketPrices(params) {
-  return marketForecast(params);
+export function fetchMarketPrices(params = {}) {
+  // Provide sensible defaults so the dashboard can call this without args
+  const { commodity = "wheat", mandi = "delhi", horizon_days = 7 } = params;
+  return marketForecast({ commodity, mandi, horizon_days });
 }
 
 // Weather


### PR DESCRIPTION
## Summary
- Make market forecast API handle empty request bodies with sensible defaults
- Send default commodity and mandi values from frontend API helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c427fc0ecc832b939c92b5e83d5739